### PR TITLE
Add transparency to blue line

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,13 +17,13 @@ A suite of codes to find extrasolar planets
 ## Installation Instructions ##
 
 1. clone the git repo. Will create a `</path/to/terra>` directory
-2. cd into traget directory
+2. cd into target directory
    
    ```
    /global/homes/p/petigura/code_carver/terra
    ```
    
-3. Bulid the cython and fortran extensions with make. At NERSC, there was a little difficulty getting the fortran and c libraries to compile. Here's what I had to do:
+3. Build the cython and fortran extensions with make. At NERSC, there was a little difficulty getting the fortran and c libraries to compile. Here's what I had to do:
 
    ```
    module load gcc

--- a/terra/plotting/kplot.py
+++ b/terra/plotting/kplot.py
@@ -5,8 +5,8 @@ Plotting methods for the following classes
 - Grid 
 - Peak
 
-I define these functions in a seperate module so the classes
-themselves can be instanated with out import matplotlib which is not
+I define these functions in a separate module so the classes
+themselves can be instantiated without importing matplotlib which is not
 possible on some non-interactive platforms
 """
 from scipy import ndimage as nd
@@ -309,7 +309,7 @@ def helper(i):
 
 def addtrans(raw,y,label,plot):
     """
-    Add little triangles marking where the transis are.
+    Add little triangles marking where the transits are.
     """
     if raw.dtype.names.count('finj')==1:
         finjkw = dict(color='m',mew=2,marker=7,ms=5,lw=0,mfc='none')

--- a/terra/plotting/pipeline.py
+++ b/terra/plotting/pipeline.py
@@ -119,7 +119,7 @@ def diagnostic(pipe):
     plt.xlabel('Phase')
     plt.ylabel('Flux')
 
-    # Sinngle Event Statistic Stack
+    # Single Event Statistic Stack
     plt.sca(axSES)
     mad = pipe.lc.f.abs().median()
     ystep = 3 * 1.6 * mad
@@ -129,7 +129,7 @@ def diagnostic(pipe):
     pipe.se_phase 
     plt.axvline(0, alpha=.1,lw=10,color='m',zorder=1)
 
-    # Sinngle Event Statistic Stack
+    # Single Event Statistic Stack
     plt.sca(axTransitStack)
     transit_stack(pipe,ystep=ystep)
 

--- a/terra/plotting/pipeline.py
+++ b/terra/plotting/pipeline.py
@@ -273,7 +273,8 @@ def phasefold_transit(pipe, mode='transit'):
 
     if type(lcfit) is not type(None):
         lcfit = lcfit.sort_values('t_phasefold')
-        plt.plot(lcfit.t_phasefold, lcfit.f, lw=2, color='RoyalBlue')
+        plt.plot(lcfit.t_phasefold, lcfit.f, lw=2, color='RoyalBlue', 
+                 alpha=0.7)
 
     plt.xlim(*xl) # reset the x-limits 
     plt.ylim(*yl) # reset the x-limits 


### PR DESCRIPTION
So on https://www.zooniverse.org/projects/ianc2/exoplanet-explorers I saw this plot:

![0668619e-e1ed-4462-a66e-6f5636c35236](https://cloud.githubusercontent.com/assets/58611/24734342/c90f5552-1a4a-11e7-903c-eb36f5fd51be.png)

and thought it would be better if the blue line were translucent, so I went looking for the code, and in the process I fixed some typos too.